### PR TITLE
embedding list check

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ def most_similar(
     record_id: str,
     limit: int = 100,
     att_filter: Optional[List[Dict[str, Any]]] = None,
+    record_sub_key: Optional[int] = None,
 ) -> responses.JSONResponse:
     """Find the n most similar records with respect to the specified record.
 
@@ -35,7 +36,7 @@ def most_similar(
     """
     session_token = general.get_ctx_token()
     similar_records = util.most_similar(
-        project_id, embedding_id, record_id, limit, att_filter
+        project_id, embedding_id, record_id, limit, att_filter, record_sub_key
     )
     general.remove_and_refresh_session(session_token)
     return responses.JSONResponse(

--- a/neural_search/util.py
+++ b/neural_search/util.py
@@ -25,8 +25,9 @@ def most_similar(
     record_id: str,
     limit: int = 100,
     att_filter: Optional[List[Dict[str, Any]]] = None,
+    record_sub_key: Optional[int] = None,
 ):
-    embedding_item = embedding.get_tensor(embedding_id, record_id)
+    embedding_item = embedding.get_tensor(embedding_id, record_id,record_sub_key)
     embedding_tensor = embedding_item.data
     return most_similar_by_embedding(
         project_id, embedding_id, embedding_tensor, limit, att_filter

--- a/neural_search/util.py
+++ b/neural_search/util.py
@@ -27,7 +27,7 @@ def most_similar(
     att_filter: Optional[List[Dict[str, Any]]] = None,
     record_sub_key: Optional[int] = None,
 ):
-    embedding_item = embedding.get_tensor(embedding_id, record_id,record_sub_key)
+    embedding_item = embedding.get_tensor(embedding_id, record_id, record_sub_key)
     embedding_tensor = embedding_item.data
     return most_similar_by_embedding(
         project_id, embedding_id, embedding_tensor, limit, att_filter
@@ -48,6 +48,8 @@ def most_similar_by_embedding(
     has_sub_key = embedding.has_sub_key(project_id, embedding_id)
     if has_sub_key:
         # new tmp limit to ensure that we get enough results for embedding lists
+        # since the limit factor is just an average of embedding list entries rounded up this could be to little depending on the
+        # explicit question and the amount of matched sub_keys so we add another 25 to be sure
         limit_factor = embedding.get_qdrant_limit_factor(project_id, embedding_id)
         tmp_limit = (limit * limit_factor) + 25
     query_vector = np.array(embedding_tensor)

--- a/neural_search/util.py
+++ b/neural_search/util.py
@@ -47,7 +47,8 @@ def most_similar_by_embedding(
     has_sub_key = embedding.has_sub_key(project_id, embedding_id)
     if has_sub_key:
         # new tmp limit to ensure that we get enough results for embedding lists
-        tmp_limit = (limit * 3) + 25
+        limit_factor = embedding.get_qdrant_limit_factor(project_id, embedding_id)
+        tmp_limit = (limit * limit_factor) + 25
     query_vector = np.array(embedding_tensor)
     similarity_threshold = threshold
     if similarity_threshold is None:


### PR DESCRIPTION
- https://github.com/code-kern-ai/refinery-gateway/pull/148
- https://github.com/code-kern-ai/refinery-submodule-model/pull/51
- https://github.com/code-kern-ai/refinery-ac-exec-env/pull/27
- https://github.com/code-kern-ai/refinery-embedder/pull/58
- https://github.com/code-kern-ai/refinery-ui/pull/153
- https://github.com/code-kern-ai/refinery-neural-search/pull/36
- https://github.com/code-kern-ai/gates-runtime/pull/31


Note:
Gates was pretty much left untouched for the moment since other prs that change the structure are still in review queue & I'm unsure how we want to approach gates in the future (specify what is wanted, e.g. the new embedding_list attribute is atm fully returned etc,)

Best option to test:
`sudo bash start -g -b embedding-list` (newest dev setup version is needed -> this will start refinery & gates on the specified branch)

**otherwise:** remember to build the ac exec env & gates runtime to test :) 


