### PR TITLE
Outlier Search on unlabeled data

### DIFF
--- a/neural_search/util.py
+++ b/neural_search/util.py
@@ -252,7 +252,7 @@ def detect_outliers(
     project_id: str, embedding_id: str, limit: int = 100
 ) -> Tuple[int, Union[List[Any], str]]:
     unlabeled_tensors = embedding.get_not_manually_labeled_tensors_by_embedding_id(
-        project_id, embedding_id
+        project_id, embedding_id, 10000
     )
     if len(unlabeled_tensors) < 1:
         return status.HTTP_200_OK, [[], []]
@@ -261,7 +261,7 @@ def detect_outliers(
     unlabeled_embeddings = np.array(unlabeled_embeddings)
 
     labeled_tensors = embedding.get_manually_labeled_tensors_by_embedding_id(
-        project_id, embedding_id
+        project_id, embedding_id, 10000
     )
 
     if len(labeled_tensors) < 1:

--- a/neural_search/util.py
+++ b/neural_search/util.py
@@ -278,12 +278,20 @@ def detect_outliers(
         axis=None,
     )[::-1]
 
-    max_records = min(round(0.05 * len(sorted_index)), limit)
+    count_unlabeled = record.count_records_without_manual_label(project_id)
+    max_records = min(round(0.05 * count_unlabeled), limit)
 
-    outlier_ids = np.array(unlabeled_ids)[sorted_index[:max_records]]
-    outlier_scores = outlier_scores[sorted_index[:max_records]]
+    i = 0
+    outlier_slice_ids = []
+    outlier_slics_scores = []
+    while len(outlier_slice_ids) < max_records and i < len(sorted_index):
+        outlier_id = unlabeled_ids[sorted_index[i]]
+        if outlier_id not in outlier_slice_ids:
+            outlier_slice_ids.append(outlier_id)
+            outlier_slics_scores.append(outlier_scores[sorted_index[i]])
+        i += 1
 
-    return status.HTTP_200_OK, [outlier_ids.tolist(), outlier_scores.tolist()]
+    return status.HTTP_200_OK, [outlier_slice_ids, outlier_slics_scores]
 
 
 def update_attribute_payloads(


### PR DESCRIPTION
Related PRs:
- https://github.com/code-kern-ai/refinery-gateway/pull/163
- https://github.com/code-kern-ai/refinery-ui/pull/159
- https://github.com/code-kern-ai/refinery-neural-search/pull/45
- https://github.com/code-kern-ai/refinery-submodule-model/pull/58

Enables the creation of an outlier slice on a project that contains no manually labeled data.
Instead of the already labeled data, the mean vector is used as the reference vector.

UI and gateway contain small changes, so that outlier slices are not blocked when no data is manually labeled.

To test, you can use the dev-setup in the following way: `bash start -b initial-outliers`