### PR TITLE
ci(pi): kernai/refinery-parent-images:v1.19.1-common

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernai/refinery-parent-images:v1.19.0-common
+FROM kernai/refinery-parent-images:v1.19.1-common
 
 WORKDIR /program
 


### PR DESCRIPTION
Automated parent image release for:
- https://github.com/code-kern-ai/refinery-common-parent-image/releases/tag/v1.19.1